### PR TITLE
Fix: Add class 'lazy' instead of overwriting

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function img_lazy_plugin(md, options) {
         var src = typeof prefix === 'function' ? prefix(srcValue) : prefix + srcValue;
         token.attrPush(['data-src', src]);
         useNative && token.attrPush(['loading', 'lazy']);
-        token.attrPush(['class', selector]);
+        token.attrJoin('class', selector);
         token.attrs.splice(aIndex, 1);
         return defaultImageRenderer(tokens, idx, options, env, self);
     };


### PR DESCRIPTION
Hey, fantastic job on this plugin!

I'd love to use it in my project, however I've discovered a little issue.
When my `<img>` tag has assigned classes to it already, `attrPush` would overwrite these classes, removing my existing styling.
By using `attrJoin` instead, the `lazy` class will be added to the class list, instead of overwriting existing classes.

Documentation can be found here: https://markdown-it.github.io/markdown-it/#Token.attrJoin

Thank you!
